### PR TITLE
Challange 04 state object

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,7 @@
     transform: rotate(360deg);
   }
 }
+
+.App:first-child{
+  background-color:white;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,29 +1,14 @@
 import logo from './logo.svg';
 import './App.css';
-import MyButton from './MyButton';
-import MangingState from './MangingState';
-import MangingStateForm from './MangingStateForm';
+import UpdatingObjectState from './UpdatingObjectState';
+
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-header App-logo" alt="logo"/>
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-        <MyButton/>
-        <MangingState/>
-        <h1>-------- State Forms --------</h1>
-        <MangingStateForm/>
+        <UpdatingObjectState/>
+        
       </header>
     </div>
   );

--- a/src/UpdatingObjectState.js
+++ b/src/UpdatingObjectState.js
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+export default function Scoreboard() {
+  const [player, setPlayer] = useState({
+    firstName: 'Ranjani',
+    lastName: 'Shettar',
+    score: 10,
+  });
+
+  function handlePlusClick() {
+    player.score++;
+  }
+
+  function handleFirstNameChange(e) {
+    setPlayer({
+      ...player,
+      firstName: e.target.value,
+    });
+  }
+
+  function handleLastNameChange(e) {
+    setPlayer({
+      lastName: e.target.value
+    });
+  }
+
+  return (
+    <>
+      <label>
+        Score: <b>{player.score}</b>
+        {' '}
+        <button onClick={handlePlusClick}>
+          +1
+        </button>
+      </label>
+      <label>
+        First name:
+        <input
+          value={player.firstName}
+          onChange={handleFirstNameChange}
+        />
+      </label>
+      <label>
+        Last name:
+        <input
+          value={player.lastName}
+          onChange={handleLastNameChange}
+        />
+      </label>
+    </>
+  );
+}

--- a/src/UpdatingObjectState.js
+++ b/src/UpdatingObjectState.js
@@ -8,6 +8,10 @@ export default function Scoreboard() {
   });
 
   function handlePlusClick() {
+    setPlayer({
+        ...player,
+        score:player.score + 1,
+    })
     player.score++;
   }
 


### PR DESCRIPTION
 `handlePlusClick` : mutates the player object directly (player.score++), so React doesn't detect the change and doesn't re-render the component.

`handleLastNameChange ` : replaces the whole player object without preserving the existing fields, which causes loss of data like score.

In the fixed version:

`handlePlusClick `correctly uses setPlayer with a copied object and an updated score.

`handleLastNameChange` now preserves the rest of the player fields using the spread operator (...player), preventing data loss.

